### PR TITLE
Avoid signed index representation in gamepad axes configuration

### DIFF
--- a/config/gamepads.yml
+++ b/config/gamepads.yml
@@ -2,12 +2,10 @@ players:
   # <id>: // A unique id (integer) for the player
   #   gamepadMapping: // The mapping of the gamepad
   #     axes: // The mapping of the axes (negative index means the axis is inverted; -0 does not work, use -0.0 instead)
-  #       up: <integer> // The id of the up axis
-  #       down: <integer> // The id of the down axis
-  #       left: <integer> // The id of the left axis
-  #       right: <integer> // The id of the right axis
-  #       action: <integer> // The id of the axis to use for the action button
-  #       lang: <integer> // The id of the axis to use for the lang button
+  #       horizontal: <integer> // The axis index of the horizontal axis
+  #       vertical: <integer> // The axis index of the vertical axis
+  #       invertHorizontal: <boolean> // Whether the horizontal axis is inverted
+  #       invertVertical: <boolean> // Whether the vertical axis is inverted
   #     buttons: // The mapping of the buttons
   #       up: <integer> // The id of the up button
   #       down: <integer> // The id of the down button
@@ -18,10 +16,10 @@ players:
   1:
     gamepadMapping:
       axes:
-        up: -1
-        down: 1
-        left: -0.0
-        right: 0
+        horizontal: 0
+        vertical: 1
+        invertHorizontal: false
+        invertVertical: false
 
       buttons:
         action: 1


### PR DESCRIPTION
Using a signed index for representing an axis index and a direction in a single number may result in problematic behavior when the signed index -0 (negative zero) is used. While JS IEEE 754 numbers include a valid representation for negative zero, the sign is lost during string conversion via JSON.stringify(), i.e. when the config is read via the API server and not directly via the HTTP file server.

The updated configuration format avoids signed indices, but instead allows for negating the horizontal or vertical axis if necessary.

See config/gamepads.xml for the documented of the updated gamepad configuration schema.

Note that this PR does not include updated compilation results. Just add them in the merge commit, if needed.